### PR TITLE
refactor: rename @KafkaEvents to @EventProducer

### DIFF
--- a/data-jpa-event-producer-spring-boot-autoconfigure/src/main/java/com/github/spring/data/jpa/event/producer/autoconfigure/DataJpaEventProducerAutoconfiguration.java
+++ b/data-jpa-event-producer-spring-boot-autoconfigure/src/main/java/com/github/spring/data/jpa/event/producer/autoconfigure/DataJpaEventProducerAutoconfiguration.java
@@ -61,12 +61,12 @@ public class DataJpaEventProducerAutoconfiguration {
 
     return entityManager.getMetamodel().getEntities().stream()
         .map(EntityType::getJavaType)
-        .filter(entityClass -> entityClass.isAnnotationPresent(KafkaEvents.class))
+        .filter(entityClass -> entityClass.isAnnotationPresent(EventProducer.class))
         .map(
             entityClass ->
                 new EntityEventToKafkaEventHandler<>(
                     entityClass.getName(),
-                    entityClass.getAnnotation(KafkaEvents.class).topic(),
+                    entityClass.getAnnotation(EventProducer.class).topic(),
                     new EntityToEventMapperDefaultImpl<>(objectMapper),
                     kafkaTemplate))
         .collect(toSet());

--- a/data-jpa-event-producer-spring-boot-autoconfigure/src/main/java/com/github/spring/data/jpa/event/producer/autoconfigure/EventProducer.java
+++ b/data-jpa-event-producer-spring-boot-autoconfigure/src/main/java/com/github/spring/data/jpa/event/producer/autoconfigure/EventProducer.java
@@ -9,7 +9,7 @@ import java.lang.annotation.Target;
 @Documented
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface KafkaEvents {
+public @interface EventProducer {
   /** The kafka topic name where the generated events will be produced. */
   String topic();
 }

--- a/data-jpa-event-producer-spring-boot-sample-app/src/main/java/com/github/spring/data/jpa/event/producer/sample/organization/Organization.java
+++ b/data-jpa-event-producer-spring-boot-sample-app/src/main/java/com/github/spring/data/jpa/event/producer/sample/organization/Organization.java
@@ -1,7 +1,7 @@
 package com.github.spring.data.jpa.event.producer.sample.organization;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.github.spring.data.jpa.event.producer.autoconfigure.KafkaEvents;
+import com.github.spring.data.jpa.event.producer.autoconfigure.EventProducer;
 import com.github.spring.data.jpa.event.producer.sample.user.User;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -12,7 +12,7 @@ import java.util.UUID;
 import lombok.Data;
 
 @Entity
-@KafkaEvents(topic = "organization")
+@EventProducer(topic = "organization")
 @Table(name = "organization")
 @Data
 public class Organization {

--- a/data-jpa-event-producer-spring-boot-sample-app/src/main/java/com/github/spring/data/jpa/event/producer/sample/user/User.java
+++ b/data-jpa-event-producer-spring-boot-sample-app/src/main/java/com/github/spring/data/jpa/event/producer/sample/user/User.java
@@ -1,7 +1,7 @@
 package com.github.spring.data.jpa.event.producer.sample.user;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.github.spring.data.jpa.event.producer.autoconfigure.KafkaEvents;
+import com.github.spring.data.jpa.event.producer.autoconfigure.EventProducer;
 import com.github.spring.data.jpa.event.producer.sample.organization.Organization;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -13,7 +13,7 @@ import java.util.UUID;
 import lombok.Data;
 
 @Entity
-@KafkaEvents(topic = "user")
+@EventProducer(topic = "user")
 @Table(name = "\"user\"")
 @Data
 public class User {


### PR DESCRIPTION
## Summary

- Renames `@KafkaEvents` to `@EventProducer` for symmetry with the consumer module's `@EventDriven`
- Deletes `KafkaEvents.java`, introduces `EventProducer.java`
- Updates `DataJpaEventProducerAutoconfiguration` and both sample-app entities

The final API across both modules:
\`\`\`java
@EventProducer(topic = "user") // producer side
@EventDriven(topic = "user")   // consumer side
\`\`\`

## Test plan
- [ ] CI passes (build + integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)