### PR TITLE
fix: upgrade jackson to 2.21.1 to address GHSA-72hv-8253-57qq

### DIFF
--- a/buildSrc/src/main/groovy/jpa-events.java-convention.gradle
+++ b/buildSrc/src/main/groovy/jpa-events.java-convention.gradle
@@ -28,6 +28,10 @@ spotless {
   }
 }
 
+// Override jackson-bom version to fix GHSA-72hv-8253-57qq (DoS via Number Length Constraint Bypass
+// in Async Parser). Spring Boot 3.5.x ships jackson-core 2.19.4 which is unmaintained; 2.21.1 is fixed.
+ext['jackson-bom.version'] = '2.21.1'
+
 dependencyManagement {
 	imports {
 		mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES


### PR DESCRIPTION
Spring Boot 3.5.x ships jackson-core 2.19.4 which is affected by a
Number Length Constraint Bypass in the Async Parser (GHSA-72hv-8253-57qq).
The 2.19.x line is unmaintained; the fix is available in 2.21.1 (LTS).

Override the jackson-bom.version managed by the Spring Boot BOM to
pull in jackson-core/jackson-databind 2.21.1 instead.

https://github.com/FasterXML/jackson-core/security/advisories/GHSA-72hv-8253-57qq
https://claude.ai/code/session_01LWdD5ht9GyQLR8VAgRN7oF